### PR TITLE
feat: added ChallengerMode config option

### DIFF
--- a/bin/src/op-challenger.rs
+++ b/bin/src/op-challenger.rs
@@ -8,7 +8,8 @@ use ethers::{
     signers::LocalWallet,
 };
 use op_challenger_driver::{
-    DisputeFactoryDriver, Driver, DriverConfig, OutputAttestationDriver, TxDispatchDriver,
+    ChallengerMode, DisputeFactoryDriver, Driver, DriverConfig, OutputAttestationDriver,
+    TxDispatchDriver,
 };
 use std::sync::Arc;
 use tokio::task::JoinSet;
@@ -63,6 +64,15 @@ struct Args {
         env = "OP_CHALLENGER_L2OO"
     )]
     l2_output_oracle: Address,
+
+    /// The mode to run the challenger in.
+    #[arg(
+        long,
+        default_value = "listen-and-respond",
+        help = "The mode to run the challenger in.",
+        env = "OP_CHALLENGER_MODE"
+    )]
+    mode: ChallengerMode,
 }
 
 #[tokio::main]
@@ -75,6 +85,7 @@ async fn main() -> Result<()> {
         signer_key,
         dispute_game_factory,
         l2_output_oracle,
+        mode,
     } = Args::parse();
 
     // Initialize the tracing subscriber
@@ -102,6 +113,7 @@ async fn main() -> Result<()> {
         node_endpoint,
         dispute_game_factory,
         l2_output_oracle,
+        mode,
     ));
     tracing::info!(target: "op-challenger-cli", "Driver config created successfully.");
 

--- a/crates/driver/src/config.rs
+++ b/crates/driver/src/config.rs
@@ -1,6 +1,6 @@
 //! The `config` module contains the [DriverConfig].
 
-use crate::SignerMiddlewareWS;
+use crate::{ChallengerMode, SignerMiddlewareWS};
 use ethers::{
     providers::{Http, Provider},
     types::{transaction::eip2718::TypedTransaction, Address},
@@ -25,6 +25,8 @@ pub struct DriverConfig {
     pub tx_sender: mpsc::Sender<TypedTransaction>,
     /// The receiving handle of the MPSC channel used to send transactions.
     pub tx_receiver: Mutex<mpsc::Receiver<TypedTransaction>>,
+    /// The mode of the challenger.
+    pub mode: ChallengerMode,
 }
 
 impl DriverConfig {
@@ -34,6 +36,7 @@ impl DriverConfig {
         node_provider: Arc<Provider<Http>>,
         dispute_game_factory: Address,
         l2_output_oracle: Address,
+        mode: ChallengerMode,
     ) -> Self {
         // Create a new MPSC channel for sending transactions from the drivers.
         let (tx_sender, tx_receiver) = mpsc::channel(128);
@@ -45,6 +48,7 @@ impl DriverConfig {
             l2_output_oracle,
             tx_sender,
             tx_receiver: Mutex::new(tx_receiver),
+            mode,
         }
     }
 }

--- a/crates/driver/src/handlers.rs
+++ b/crates/driver/src/handlers.rs
@@ -1,6 +1,6 @@
 use crate::{
     bindings::{DisputeGame_Factory, DisputeGame_OutputAttestation},
-    utils, DriverConfig, GameType, SignerMiddlewareWS,
+    utils, ChallengerMode, DriverConfig, GameType, SignerMiddlewareWS,
 };
 use anyhow::Result;
 use ethers::{
@@ -72,22 +72,29 @@ pub async fn output_proposed(
                 if !is_pending_challenge {
                     tracing::info!(target: "output-attestation-driver", "No pending challenge found, submitting challenge to L1.");
 
-                    // Send a challenge creation transaction to the L1 dispute game factory.
-                    config
-                        .tx_sender
-                        .send(
-                            factory
-                                .create(
-                                    GameType::OutputAttestation as u8,
-                                    proposed_root.to_fixed_bytes(),
-                                    ethers::abi::encode(&[Token::Uint(U256::from(
-                                        *proposed_block,
-                                    ))])
-                                    .into(),
+                    match config.mode {
+                        ChallengerMode::ListenAndRespond => {
+                            // Send a challenge creation transaction to the L1 dispute game factory.
+                            config
+                                .tx_sender
+                                .send(
+                                    factory
+                                        .create(
+                                            GameType::OutputAttestation as u8,
+                                            proposed_root.to_fixed_bytes(),
+                                            ethers::abi::encode(&[Token::Uint(U256::from(
+                                                *proposed_block,
+                                            ))])
+                                            .into(),
+                                        )
+                                        .tx,
                                 )
-                                .tx,
-                        )
-                        .await?;
+                                .await?;
+                        }
+                        ChallengerMode::ListenOnly => {
+                            tracing::info!(target: "output-attestation-driver", "Not submitting challenge to L1, mode is set to `ListenOnly`.");
+                        }
+                    }
                 } else {
                     tracing::debug!(target: "output-attestation-driver", "Pending challenge found, waiting for the game to be created.")
                 }
@@ -146,20 +153,28 @@ pub async fn game_created_output_attestation(
                 root_claim,
                 l2_block_number
             );
-            config
-                .tx_sender
-                .send(
-                    game.challenge(
-                        ethers::abi::encode(&[
-                            Token::Uint(signed_root.r),
-                            Token::Uint(signed_root.s),
-                            Token::Uint(signed_root.v.into()),
-                        ])
-                        .into(),
-                    )
-                    .tx,
-                )
-                .await?;
+
+            match config.mode {
+                ChallengerMode::ListenAndRespond => {
+                    config
+                        .tx_sender
+                        .send(
+                            game.challenge(
+                                ethers::abi::encode(&[
+                                    Token::Uint(signed_root.r),
+                                    Token::Uint(signed_root.s),
+                                    Token::Uint(signed_root.v.into()),
+                                ])
+                                .into(),
+                            )
+                            .tx,
+                        )
+                        .await?;
+                }
+                ChallengerMode::ListenOnly => {
+                    tracing::info!(target: "dispute-factory-driver", "Not challenging in game {}, mode is set to `ListenOnly`.", game_addr);
+                }
+            }
         }
     }
 

--- a/crates/driver/src/types.rs
+++ b/crates/driver/src/types.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use ethers::{
     prelude::SignerMiddleware,
     providers::{Provider, Ws},
@@ -35,4 +37,31 @@ pub(crate) type SignerMiddlewareWS = SignerMiddleware<Provider<Ws>, LocalWallet>
 #[serde(rename_all = "camelCase")]
 pub(crate) struct OutputAtBlockResponse {
     pub output_root: H256,
+}
+
+/// The [ChallengerMode] enum defines the different modes of operation for the challenger.
+#[derive(Debug, Serialize, Deserialize, Default, Clone)]
+pub enum ChallengerMode {
+    /// The challenger will only listen for new games and report
+    /// the disputes to the console without sending any transactions.
+    ListenOnly,
+
+    /// The challenger will listen for new disputes and respond to them
+    /// by sending transactions.
+    #[default]
+    ListenAndRespond,
+}
+
+impl FromStr for ChallengerMode {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "listen-only" => Ok(ChallengerMode::ListenOnly),
+            "listen-and-respond" => Ok(ChallengerMode::ListenAndRespond),
+            _ => Err(anyhow::anyhow!(
+                "Invalid challenger mode. Supported modes are: `listen-only` and `listen-and-respond`"
+            )),
+        }
+    }
 }


### PR DESCRIPTION
After #1 

- added possibility to specify the mode in which to run the challenger
- available modes are:
  1. `listen-and-respond`: working exactly the same as before, and is the default
  2. `listen-only`: the challenger will not send any transaction, but instead only emit logs